### PR TITLE
Windows 10 April 2018 Update SDK (17134)

### DIFF
--- a/xtuvatlas_Desktop_2017.vcxproj
+++ b/xtuvatlas_Desktop_2017.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{240C940F-C975-43F1-8E72-5B912F258E11}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>xtuvatlas</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Updated VS 2017 project to use the Windows 10 SDK (17134) which requires the VS 2017 (15.7 update)
